### PR TITLE
fix feat holiday favourite

### DIFF
--- a/src/app/holidays/feat-overview/holidays/holidays.component.ts
+++ b/src/app/holidays/feat-overview/holidays/holidays.component.ts
@@ -151,11 +151,21 @@ export class HolidaysComponent {
 
   addFavourite(id: number) {
     this.holidaysService.addFavourite(id);
-    this.search();
+    this.setFavouriteLocally(id, true);
   }
 
   removeFavourite(id: number) {
     this.holidaysService.removeFavourite(id);
-    this.search();
+    this.setFavouriteLocally(id, false);
+  }
+
+  private setFavouriteLocally(id: number, isFavourite: boolean) {
+    this.holidays.update((holidays) =>
+      holidays.map((holiday) =>
+        holiday.id === id
+          ? { ...holiday, isFavourite: isFavourite }
+          : holiday,
+      ),
+    );
   }
 }

--- a/src/app/holidays/ui/holiday-card/holiday-card.component.html
+++ b/src/app/holidays/ui/holiday-card/holiday-card.component.html
@@ -11,8 +11,8 @@
   >
     <mat-card-header>
       <mat-card-title [id]="'holiday-card-' + holiday().id">
-        {{ holiday().title }}</mat-card-title
-      >
+        {{ holiday().title }}
+      </mat-card-title>
       <mat-card-subtitle>{{ holiday().teaser }}</mat-card-subtitle>
     </mat-card-header>
 
@@ -35,37 +35,41 @@
       {{ holiday().description }}
     </mat-card-content>
     <mat-card-actions class="flex justify-around items-center">
-      @if (holiday().isFavourite) {
-        <button mat-icon-button data-testid="btn-remove-favourite">
-          <mat-icon (click)="removeFavourite.emit(holiday().id)"
-            >favorite
-          </mat-icon>
-        </button>
-      }
       @if (holiday().hasQuiz) {
-        <a [routerLink]="['./quiz', holiday().id]" mat-icon-button
-          ><mat-icon>quiz</mat-icon></a
-        >
+        <a [routerLink]="['./quiz', holiday().id]" mat-icon-button>
+          <mat-icon>quiz</mat-icon>
+        </a>
       }
-      @if (!holiday().isFavourite) {
-        <button mat-icon-button data-testid="btn-add-favourite">
-          <mat-icon (click)="addFavourite.emit(holiday().id)"
-            >favorite_outlined
-          </mat-icon>
+      @if (holiday().isFavourite) {
+        <button
+          (click)="removeFavourite.emit(holiday().id)"
+          mat-icon-button
+          data-testid="btn-remove-favourite"
+        >
+          <mat-icon>favorite</mat-icon>
+        </button>
+      } @else {
+        <button
+          (click)="addFavourite.emit(holiday().id)"
+          mat-icon-button
+          data-testid="btn-add-favourite"
+        >
+          <mat-icon>favorite_outlined</mat-icon>
         </button>
       }
       <mat-icon
         data-testid="btn-basket"
         class="cursor-pointer"
         (click)="selected.set(holiday().id)"
-        >shopping_cart</mat-icon
-      >
+        >shopping_cart
+      </mat-icon>
       <a
         [routerLink]="['./request-info', holiday().id]"
         data-testid="btn-brochure"
         mat-icon-button
-        ><mat-icon>info</mat-icon></a
       >
+        <mat-icon>info</mat-icon>
+      </a>
     </mat-card-actions>
   </mat-card>
 </div>


### PR DESCRIPTION
1. Just noticed that the hole "favorite" feature does not work
because the click-event listener is not placed correctly.
so:

- moved the (click) listener from the `<mat-icon> `to the `<button>`

now favoriting works.

2. After the button worked, I noticed that the behavior of the button placement is wierd.
- If not favorited, the fav-button is after the quiz button
- If favorited, the fav-button is before the quiz-button
so:
- put the fav and !fav button declaration together, with if-else logic

3. Refetching after favoriting and unfavoriting is an unexpected behavior in my opinion. Especially when
you have entered a search string but didn't search, and then favorite something, items "magically" disappear, as the search is now triggered with the new query string.
so:
- set the favoriting "locally" instead of "refetch" with search()


All in all, of course, it's just an example app, but I think it's nice when the features actually work.
Hope this helps.

